### PR TITLE
feat: add fullnameOverride, commonAnnotations, nodeSelector, tolerations and resources to Helm chart

### DIFF
--- a/helm/kubedock-dns/templates/_helpers.tpl
+++ b/helm/kubedock-dns/templates/_helpers.tpl
@@ -1,4 +1,20 @@
 
-{{- define  "labels" }}
+{{- define "labels" }}
 app.kubernetes.io/name: kubedock-dns
 {{- end }}
+
+{{/*
+fullname returns .Values.fullnameOverride when set, otherwise .Release.Name.
+The result is truncated to 50 characters and trailing dashes are removed.
+50 is chosen so that the longest derived name in this chart ("<fullname>-mutator-cert",
++13 characters) never exceeds the Kubernetes 63-character name limit.
+Use this everywhere a resource name is derived from the release name so that
+operators can deploy multiple instances without naming collisions.
+*/}}
+{{- define "fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 50 | trimSuffix "-" -}}
+{{- else -}}
+{{- .Release.Name | trunc 50 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}

--- a/helm/kubedock-dns/templates/dns-mutator-config.yaml
+++ b/helm/kubedock-dns/templates/dns-mutator-config.yaml
@@ -20,7 +20,8 @@ See https://masterminds.github.io/sprig/crypto.html for docs on the cryptographi
 {{/*
     { "namespace": namespace,
       "cacert": decoded-cacert,
-      "label": label }
+      "label": label,
+      "annotations": commonAnnotations }
 */}}
 {{- define "dns-mutator-config" }}
 apiVersion: admissionregistration.k8s.io/v1
@@ -30,6 +31,10 @@ metadata:
   name: {{ .namespace }}-dns-mutator-config
   labels:
     {{- include "labels" . | nindent 4 }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 webhooks:
   - name: dns-mutator.kubedock.org
     namespaceSelector:
@@ -61,8 +66,8 @@ webhooks:
 {{- end }}
 
 
-
-{{- $secretName := (printf "%s-mutator-cert" .Release.Name) }}
+{{- $name := include "fullname" . }}
+{{- $secretName := (printf "%s-mutator-cert" $name) }}
 {{- $secret := lookup "v1" "Secret" .Release.Namespace $secretName }}
 
 {{ $ca := dict }}
@@ -70,10 +75,10 @@ webhooks:
 {{ $cacert := dict }}
 
 {{- if not $secret }}
-  {{- $ca = genCA .Release.Name 10000 }}
+  {{- $ca = genCA $name 10000 }}
   {{- $cert = genSignedCert "dnsmutator" nil (
-        list "dns-mutator" (printf "%s-server.%s" .Release.Name .Release.Namespace)
-                           (printf "%s-server.%s.svc" .Release.Name .Release.Namespace)
+        list "dns-mutator" (printf "%s-server.%s" $name .Release.Namespace)
+                           (printf "%s-server.%s.svc" $name .Release.Namespace)
       ) 365 $ca }}
 {{- else }}
   # Secret {{ $secretName }} is re-used so that there is no downtime during upgrades.
@@ -89,17 +94,21 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secretName }}
-  namespace: {{.Release.Namespace}}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   ca.crt: "{{ $ca.Cert | b64enc }}"
   tls.crt: "{{ $cert.Cert | b64enc }}"
   tls.key: "{{ $cert.Key | b64enc }}"
 ---
 {{- template "dns-mutator-config" (
-  dict "name" .Release.Name
+  dict "name" $name
        "namespace" .Release.Namespace
        "cacert" $ca.Cert
-       "label" .Values.label) }}
-
+       "label" .Values.label
+       "annotations" .Values.commonAnnotations) }}

--- a/helm/kubedock-dns/templates/dns-server-sa.yaml
+++ b/helm/kubedock-dns/templates/dns-server-sa.yaml
@@ -1,17 +1,26 @@
+{{- $name := include "fullname" . }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}-server
+  name: {{ $name }}-server
   labels:
     {{- include "labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Release.Name }}-server
+  name: {{ $name }}-server
   labels:
     {{- include "labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups:
       - ""
@@ -26,21 +35,25 @@ rules:
     resources:
       - services
     resourceNames:
-      - {{ .Release.Name }}-server
+      - {{ $name }}-server
     verbs:
       - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Release.Name }}-server
+  name: {{ $name }}-server
   labels:
-     {{- include "labels" . | nindent 4 }}
+    {{- include "labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Release.Name }}-server
+  name: {{ $name }}-server
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Name }}-server
+    name: {{ $name }}-server
     namespace: {{ .Release.Namespace }}

--- a/helm/kubedock-dns/templates/dns-server.yaml
+++ b/helm/kubedock-dns/templates/dns-server.yaml
@@ -63,6 +63,10 @@ spec:
             scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 10
+        {{- with .Values.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
           - mountPath: /etc/kubedock/pki
             name: pki

--- a/helm/kubedock-dns/templates/dns-server.yaml
+++ b/helm/kubedock-dns/templates/dns-server.yaml
@@ -1,22 +1,30 @@
+{{- $name := include "fullname" . }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     {{- include "labels" . | nindent 4 }}
-  name: {{ .Release.Name }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  name: {{ $name }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-server
+      app: {{ $name }}-server
   strategy: {}
   template:
     metadata:
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}
+        {{- with .Values.commonAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
-        app: {{ .Release.Name }}-server
+        app: {{ $name }}-server
         {{- include "labels" . | nindent 8 }}
     spec:
       {{- if not (empty .Values.imagePullSecrets) }}
@@ -25,21 +33,24 @@ spec:
         - name: {{ $secret }}
         {{- end }}
       {{- end }}
-
-      serviceAccountName: {{ .Release.Name }}-server
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ $name }}-server
       containers:
       - image: {{ .Values.registry }}/kubedock-dns:{{ default .Chart.Version .Values.version }}
         imagePullPolicy: Always
         name: kubedock-dns
-{{/*        command:*/}}
-{{/*          - tail*/}}
-{{/*          - -f*/}}
-{{/*          - /dev/null*/}}
         args:
           - --v
           - "{{ .Values.logLevel }}"
           - --dns-service-name
-          - {{ .Release.Name }}-server
+          - {{ $name }}-server
         ports:
           - containerPort: 1053
             name: dns
@@ -58,14 +69,18 @@ spec:
       volumes:
         - name: pki
           secret:
-            secretName: {{ .Release.Name }}-mutator-cert
+            secretName: {{ $name }}-mutator-cert
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
     {{- include "labels" . | nindent 4 }}
-  name: {{ .Release.Name }}-server
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  name: {{ $name }}-server
 spec:
   ports:
   - name: dns
@@ -77,19 +92,5 @@ spec:
     protocol: TCP
     targetPort: 8443
   selector:
-    app: {{ .Release.Name }}-server
+    app: {{ $name }}-server
   type: ClusterIP
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/helm/kubedock-dns/values.schema.json
+++ b/helm/kubedock-dns/values.schema.json
@@ -27,6 +27,31 @@
       "items": {
         "type": "string"
       }
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "Override the name used for all resources instead of .Release.Name. Truncated to 50 characters."
+    },
+    "commonAnnotations": {
+      "type": "object",
+      "description": "Annotations to add to all rendered resources.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "nodeSelector": {
+      "type": "object",
+      "description": "Node selector applied to the kubedock-dns pod.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "tolerations": {
+      "type": "array",
+      "description": "Tolerations applied to the kubedock-dns pod.",
+      "items": {
+        "type": "object"
+      }
     }
   },
   "required": [

--- a/helm/kubedock-dns/values.schema.json
+++ b/helm/kubedock-dns/values.schema.json
@@ -52,6 +52,10 @@
       "items": {
         "type": "object"
       }
+    },
+    "resources": {
+      "type": "object",
+      "description": "Resource requests and limits for the kubedock-dns container."
     }
   },
   "required": [

--- a/helm/kubedock-dns/values.yaml
+++ b/helm/kubedock-dns/values.yaml
@@ -26,3 +26,6 @@ nodeSelector: {}
 
 # Tolerations applied to the kubedock-dns pod.
 tolerations: []
+
+# Resource requests and limits for the kubedock-dns container.
+resources: {}

--- a/helm/kubedock-dns/values.yaml
+++ b/helm/kubedock-dns/values.yaml
@@ -1,15 +1,28 @@
-
-
-
 replicas: 1
 logLevel: 3
 
 # only pods with this label set to "true" will be handled
 label: kubedock
 
-# container contiguration
+# container configuration
 registry: localhost:5000
 # container version to use.
 version: 1.0.0
 
 imagePullSecrets: []
+
+# Override the name used for all resources. When set, this replaces .Release.Name
+# everywhere in the chart (deployments, services, RBAC, webhook, certificates).
+# Truncated to 50 characters so that the longest derived name in the chart
+# ("<fullname>-mutator-cert") stays within Kubernetes' 63-character name limit.
+fullnameOverride: ""
+
+# Annotations added to every rendered resource (Deployment, Service, ServiceAccount,
+# Role, RoleBinding, Secret, MutatingWebhookConfiguration).
+commonAnnotations: {}
+
+# Node selector applied to the kubedock-dns pod.
+nodeSelector: {}
+
+# Tolerations applied to the kubedock-dns pod.
+tolerations: []


### PR DESCRIPTION
- fullnameOverride: replaces .Release.Name across all chart resources (Deployment, Service, ServiceAccount, Role, RoleBinding, Secret, MutatingWebhookConfiguration). Truncated to 50 characters so that the longest derived name ('<name>-mutator-cert') stays within Kubernetes' 63-character resource name limit.

- commonAnnotations: map of annotations applied to every rendered resource.

- nodeSelector / tolerations: applied to the kubedock-dns pod spec, enabling placement on specific node pools or tainted nodes.

- resources: applied to the kubedock-dns pod to allow for better scheduling

All five values default to empty/unset so existing deployments are unaffected. values.schema.json updated accordingly.